### PR TITLE
Update Apparel_Patches.cs

### DIFF
--- a/Source/VFECore/VFECore/HarmonyPatches/Apparel_Patches.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Apparel_Patches.cs
@@ -55,7 +55,7 @@ namespace VFECore
                     yield return new CodeInstruction(OpCodes.Ldloc_1);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Pawn), "apparel"));
                     yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(Pawn_ApparelTracker), "get_WornApparel"));
-                    yield return new CodeInstruction(OpCodes.Ldloc_S, 20);
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 23);
                     yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(List<Apparel>), "get_Item"));
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(StatWorker), "stat"));

--- a/Source/VFECore/VFECore/HarmonyPatches/Apparel_Patches.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Apparel_Patches.cs
@@ -44,19 +44,27 @@ namespace VFECore
         {
             var codes = instructions.ToList();
             var statOffsetFromGearMethod = AccessTools.Method(typeof(StatWorker), nameof(StatWorker.StatOffsetFromGear));
+            var getItemMethod = AccessTools.Method(typeof(List<Apparel>), "get_Item");
             bool found = false;
+            object apparelIdx = 20;
             for (int i = 0; i < codes.Count; i++)
             {
                 yield return codes[i];
-                if (!found && codes[i].opcode == OpCodes.Stloc_0 && codes[i - 1].opcode == OpCodes.Add && codes[i - 2].Calls(statOffsetFromGearMethod))
+                if (found)
+                    continue;
+                if (codes[i].opcode == OpCodes.Ldloc_S && codes[i + 1].Calls(getItemMethod))
+                {
+                    apparelIdx = codes[i].operand;
+                }
+                else if (codes[i].opcode == OpCodes.Stloc_0 && codes[i - 1].opcode == OpCodes.Add && codes[i - 2].Calls(statOffsetFromGearMethod))
                 {
                     found = true;
                     yield return new CodeInstruction(OpCodes.Ldloc_0);
                     yield return new CodeInstruction(OpCodes.Ldloc_1);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Pawn), "apparel"));
                     yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(Pawn_ApparelTracker), "get_WornApparel"));
-                    yield return new CodeInstruction(OpCodes.Ldloc_S, 23);
-                    yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(List<Apparel>), "get_Item"));
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, apparelIdx);
+                    yield return new CodeInstruction(OpCodes.Callvirt, getItemMethod);
                     yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(StatWorker), "stat"));
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(StatWorker_GetValueUnfinalized_Transpiler), nameof(StatFactorFromGear)));


### PR DESCRIPTION
In RimWorld 1.4 the index of local iterator for pawn.apparel.WornApparel changed from 20 to 23, leading to [ArgumentOutOfRangeException](https://gist.github.com/HugsLibRecordKeeper/9e91dc5c05f5039f55d64057119b038c), this edit fixes it.  
Obviously this change is not compatible with pre-1.4 versions. IDK how you all do multi-version support.