### PR TITLE
Genes: Account for potential recursion in DamageWorker_AddInjury patch

### DIFF
--- a/Source/VFECore/Genes/Harmony/DamageWorker_AddInjury_ApplyToPawn.cs
+++ b/Source/VFECore/Genes/Harmony/DamageWorker_AddInjury_ApplyToPawn.cs
@@ -10,39 +10,27 @@ namespace VanillaGenesExpanded
     [HarmonyPatch(typeof(DamageWorker_AddInjury), "ApplyToPawn")]
     public static class VanillaGenesExpanded_DamageWorker_AddInjury_ApplyToPawn_Patch
     {
-        public static Pawn curPawn;
-        public static void Prefix(DamageInfo dinfo, Pawn pawn)
-        {
-            curPawn = pawn;
-        }
-
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codeInstructions)
         {
-            var codes = codeInstructions.ToList();
-            var field = AccessTools.Field(typeof(FleshTypeDef), "damageEffecter");
-            foreach (var code in codes)
-            {
-                yield return code;
-                if (code.LoadsField(field))
-                {
-           
-                    yield return new CodeInstruction(OpCodes.Call,
-                        AccessTools.Method(typeof(VanillaGenesExpanded_DamageWorker_AddInjury_ApplyToPawn_Patch), nameof(GetEffecterDef)));
-                }
-            }
+            var damageEffecterField = AccessTools.Field(typeof(FleshTypeDef), nameof(FleshTypeDef.damageEffecter));
+            var getEffecterDef = AccessTools.Method(typeof(VanillaGenesExpanded_DamageWorker_AddInjury_ApplyToPawn_Patch), nameof(GetEffecterDef));
+
+            return new CodeMatcher(codeInstructions)
+                .SearchForward(instr => instr.LoadsField(damageEffecterField))
+                .Insert(
+                    new CodeInstruction(OpCodes.Ldarg_2), // pawn
+                    new CodeInstruction(OpCodes.Call, getEffecterDef)
+                )
+                .InstructionEnumeration();
         }
 
-        public static EffecterDef GetEffecterDef(EffecterDef effecterDef)
+        public static EffecterDef GetEffecterDef(EffecterDef effecterDef, Pawn curPawn)
         {
             if (StaticCollectionsClass.bloodEffect_gene_pawns.ContainsKey(curPawn))
             {
                 return StaticCollectionsClass.bloodEffect_gene_pawns[curPawn];
             }
             return effecterDef;
-        }
-        public static void Postfix()
-        {
-            curPawn = null;
         }
     }
 }


### PR DESCRIPTION
Some mods may call Thing.TakeDamage() from within DamageWorker_Injury.ApplyToPawn(), e.g. from within DamageWorker_AddInjury.ApplyDamageToPart(), which is how Combat Extended's secondary damage mechanism is implemented. The current transpiler implementation in Genes does not handle such recursion gracefully and will error with something like this:

```
Exception ticking Bullet_762x51mmNATO_HE160801: System.ArgumentNullException: Value cannot be null.
Parameter name: key
  at CombatExtended.BulletCE.Impact (Verse.Thing hitThing) [0x0027a] in <9b9fccf3fc0a49af90a683eb01211735>:0
  at CombatExtended.ProjectileCE.TryCollideWith (Verse.Thing thing) [0x00221] in <9b9fccf3fc0a49af90a683eb01211735>:0
  at CombatExtended.ProjectileCE.CheckCellForCollision (Verse.IntVec3 cell) [0x0022d] in <9b9fccf3fc0a49af90a683eb01211735>:0
  at (wrapper dynamic-method) CombatExtended.ProjectileCE.CombatExtended.ProjectileCE.CheckForCollisionBetween_Patch0(CombatExtended.ProjectileCE)
  at CombatExtended.ProjectileCE.Tick () [0x0006b] in <9b9fccf3fc0a49af90a683eb01211735>:0
  at (wrapper dynamic-method) Verse.TickList.Verse.TickList.Tick_Patch0(Verse.TickList)
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) Verse.Log:Verse.Log.Error_Patch3 (string)
(wrapper dynamic-method) Verse.TickList:Verse.TickList.Tick_Patch0 (Verse.TickList)
(wrapper dynamic-method) Verse.TickManager:Verse.TickManager.DoSingleTick_Patch2 (Verse.TickManager)
Verse.TickManager:TickManagerUpdate ()
(wrapper dynamic-method) Verse.Game:Verse.Game.UpdatePlay_Patch1 (Verse.Game)
(wrapper dynamic-method) Verse.Root_Play:Verse.Root_Play.Update_Patch1 (Verse.Root_Play)
```

Fix it by looking up and passing the `pawn` argument passed to ApplyToPawn() to GetEffecterDef() instead of managing it in a state variable. This also allows removing the prefixes and postfixes that were only needed to manage said state variable.