### PR TITLE
Reduce harmony patch overhead

### DIFF
--- a/Source/VFECore/Furniture/Comps/CompRockSpawner.cs
+++ b/Source/VFECore/Furniture/Comps/CompRockSpawner.cs
@@ -215,7 +215,7 @@ namespace VanillaFurnitureExpanded
 
         private void ResetCountdown()
         {
-            if (ModLister.HasActiveModWithName("Vanilla Factions Expanded - Mechanoids"))
+            if (VFECore.ModCompatibilityCheck.VFEMechanoids)
             {
                 try
                 {

--- a/Source/VFECore/ItemProcessor/Building/Building_ItemProcessor.cs
+++ b/Source/VFECore/ItemProcessor/Building/Building_ItemProcessor.cs
@@ -1162,7 +1162,7 @@ namespace ItemProcessor
                     }
                     else
                     {
-                        if (this.def.defName.Contains("VFEM_")&&ModLister.HasActiveModWithName("Vanilla Factions Expanded - Mechanoids") ) {
+                        if (this.def.defName.Contains("VFEM_") && VFECore.ModCompatibilityCheck.VFEMechanoids ) {
                             try
                             {
                                 ((Action)(() =>

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/ITab_Patches.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/ITab_Patches.cs
@@ -21,6 +21,11 @@ namespace VFE.Mechanoids.HarmonyPatches
         public delegate Pawn PawnToShowInfoAbout(ITab_Pawn_Character __instance);
         public static readonly PawnToShowInfoAbout pawnToShowInfoAbout = AccessTools.MethodDelegate<PawnToShowInfoAbout>
             (AccessTools.Method(typeof(ITab_Pawn_Character), "get_PawnToShowInfoAbout"));
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
+        
         public static void Postfix(ITab_Pawn_Character __instance, ref bool __result)
         {
             Pawn pawn = pawnToShowInfoAbout(__instance);
@@ -33,6 +38,10 @@ namespace VFE.Mechanoids.HarmonyPatches
     public static class ITab_Pawn_Gear_Patch
     {
         public static bool drawingThingRow;
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static void Prefix()
         {
             drawingThingRow = true;
@@ -49,6 +58,10 @@ namespace VFE.Mechanoids.HarmonyPatches
         public delegate Pawn PawnToShowInfoAbout(ITab_Pawn_Gear __instance);
         public static readonly PawnToShowInfoAbout pawnToShowInfoAbout = AccessTools.MethodDelegate<PawnToShowInfoAbout>
             (AccessTools.Method(typeof(ITab_Pawn_Gear), "get_SelPawnForGear"));
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static void Postfix(ITab_Pawn_Gear __instance, ref bool __result)
         {
             if (ITab_Pawn_Gear_Patch.drawingThingRow)

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/JobDriver_Flee_MakeNewToils_Patch.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/JobDriver_Flee_MakeNewToils_Patch.cs
@@ -16,6 +16,10 @@ namespace VFE.Mechanoids.HarmonyPatches
         {
             return typeof(JobDriver_Flee).GetMethods(AccessTools.all).First(x => x.Name.Contains("<MakeNewToils>"));
         }
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var codes = instructions.ToList();

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MachinesDie.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MachinesDie.cs
@@ -13,6 +13,10 @@ namespace VFE.Mechanoids.HarmonyPatches
     [HarmonyPatch(typeof(Pawn), "Kill")]
     public static class MachinesDie
     {
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static void Postfix(Pawn __instance)
         {
             if (__instance is Machine && __instance.Faction == Faction.OfPlayer && __instance.def.butcherProducts != null)

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MainTabWindow_Patches.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MainTabWindow_Patches.cs
@@ -10,6 +10,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(MainTabWindow_Inspect), nameof(MainTabWindow_Inspect.DoInspectPaneButtons))]
 	public static class MainTabWindow_Inspect_Renaming
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		/// Show a rename button in the inspect pane when a single drone is selected.
 		public static void Postfix(Rect rect, ref float lineEndWidth)
 		{

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MechanoidsAreCapable.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MechanoidsAreCapable.cs
@@ -14,6 +14,10 @@ namespace VFE.Mechanoids.HarmonyPatches
     [HarmonyPatch(typeof(JobGiver_Work), "PawnCanUseWorkGiver")]
     public static class MechanoidsAreCapable
     {
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static void Postfix(ref bool __result, Pawn pawn, WorkGiver giver)
         {
             if (pawn is Machine && CompMachine.cachedMachinesPawns.TryGetValue(pawn, out CompMachine comp))

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MechanoidsObeyOrders.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MechanoidsObeyOrders.cs
@@ -35,6 +35,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(MechanitorUtility), "InMechanitorCommandRange")]
 	public static class MechanitorUtility_InMechanitorCommandRange_Patch
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		public static void Postfix(Pawn mech, ref bool __result)
 		{
 			if (mech is Machine)
@@ -47,6 +51,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(FloatMenuMakerMap), "CanTakeOrder")]
 	public static class MechanoidsObeyOrders
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		public static void Postfix(Pawn pawn, ref bool __result)
 		{
 			if (!__result && pawn.drafter != null && pawn is Machine && pawn.Faction != null && pawn.Faction.IsPlayer)
@@ -59,6 +67,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(Selector), "SelectInsideDragBox")]
 	public static class Selector_SelectInsideDragBox_Patch
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codeInstructions)
 		{
 			var codes = codeInstructions.ToList();
@@ -99,6 +111,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(Selector), "SelectAllMatchingObjectUnderMouseOnScreen")]
 	public static class Selector_SelectAllMatchingObjectUnderMouseOnScreen_Patch
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codeInstructions)
 		{
 			var codes = codeInstructions.ToList();
@@ -143,6 +159,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(FloatMenuMakerMap), "AddDraftedOrders")]
 	public static class AddDraftedOrders_Patch
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		public static bool Prefix(Vector3 clickPos, Pawn pawn, List<FloatMenuOption> opts)
 		{
 			if (pawn is Machine && pawn.needs.TryGetNeed<Need_Power>() is Need_Power need && need.CurLevel <= 0f)
@@ -160,7 +180,7 @@ namespace VFE.Mechanoids.HarmonyPatches
 		static SimpleSidearmsPatch()
 		{
 			SimpleSidearmsActive = ModsConfig.IsActive("PeteTimesSix.SimpleSidearms");
-			if (SimpleSidearmsActive)
+			if (SimpleSidearmsActive && VFECore.ModCompatibilityCheck.VFEMechanoids)
 			{
 				var type = AccessTools.TypeByName("PeteTimesSix.SimpleSidearms.Extensions");
 				if (type != null)
@@ -247,6 +267,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(FloatMenuMakerMap), "ChoicesAtFor")]
 	public static class FloatMenuMakerMap_ChoicesAtFor_Patch
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		public static void Postfix(ref List<FloatMenuOption> __result, Vector3 clickPos, Pawn pawn, bool suppressAutoTakeableGoto = false)
 		{
 			if (!pawn.RaceProps.Humanlike)
@@ -392,6 +416,10 @@ namespace VFE.Mechanoids.HarmonyPatches
 	[HarmonyPatch(typeof(WanderUtility), "GetColonyWanderRoot")]
 	public static class GetColonyWanderRoot_Patch
 	{
+		static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
 		public static void Postfix(ref IntVec3 __result, Pawn pawn)
 		{
 			try

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MobileTurretsShowTurrets.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MobileTurretsShowTurrets.cs
@@ -13,7 +13,10 @@ namespace VFE.Mechanoids.HarmonyPatches
     [HarmonyPatch(typeof(PawnRenderer), "CarryWeaponOpenly")]
     public static class MobileTurretsShowTurrets
     {
-
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static void Postfix(PawnRenderer __instance, ref bool __result)
         {
             if (CompMachine.cachedMachines.TryGetValue(__instance, out CompMachine value) && (value.turretAttached != null || value.Props.violent))

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/Pawn_MainDesc_Patch.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/Pawn_MainDesc_Patch.cs
@@ -6,6 +6,10 @@ namespace VFE.Mechanoids.HarmonyPatches
     [HarmonyPatch(typeof(Pawn), nameof(Pawn.MainDesc))]
     public static class Pawn_MainDesc_Patch 
     {
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static void Postfix(ref string __result)
         {
             var substringToRemove = " ";

--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/RenderTurretCentered.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/RenderTurretCentered.cs
@@ -24,6 +24,10 @@ namespace VFE.Mechanoids.HarmonyPatches
         static Vector3 east = new Vector3(0.2f, 0f, -0.22f);
         static Vector3 west = new Vector3(-0.2f, 0, -0.22f);
 
+        static bool Prepare()
+        {
+            return VFECore.ModCompatibilityCheck.VFEMechanoids;
+        }
         public static bool Prefix(PawnRenderer __instance)
         {
             if (CompMachine.cachedMachines.TryGetValue(__instance, out CompMachine compMachine))

--- a/Source/VFECore/VFECore/ModCompatibilityCheck.cs
+++ b/Source/VFECore/VFECore/ModCompatibilityCheck.cs
@@ -28,39 +28,42 @@ namespace VFECore
         public static bool CombatExtended;
 
         public static bool HumanAlienRace;
+        public static bool VFEMechanoids;
 
         static ModCompatibilityCheck()
         {
             var allMods = ModsConfig.ActiveModsInLoadOrder.ToList();
-            for (var i = 0; i < allMods.Count; i++)
+            for (var i = allMods.Count; i-- > 0;)
             {
-                var curMod = allMods[i];
+                var curModName = allMods[i].Name;
 
-                if (curMod.Name == "Dual Wield")
+                if (curModName == "Dual Wield")
                     DualWield = true;
-                else if (curMod.Name == "Facial Stuff 1.1")
+                else if (curModName == "Facial Stuff 1.1")
                     FacialStuff = true;
-                else if (curMod.Name == "Research Tree")
+                else if (curModName == "Research Tree")
                     ResearchTree = true;
-                else if (curMod.Name == "ResearchPal")
+                else if (curModName == "ResearchPal")
                     ResearchPal = true;
-                else if (curMod.Name == "RimCities")
+                else if (curModName == "RimCities")
                     RimCities = true;
-                else if (curMod.Name == "RPG Style Inventory Revamped")
+                else if (curModName == "RPG Style Inventory Revamped")
                     RPGStyleInventoryRevamped = true;
                 // Uncomment this once RPG Style Inventory updates to 1.3:
                 // else if (curMod.Name == "RPG Style Inventory")
                 //     RPGStyleInventory = true;
-                else if (curMod.Name == "RunAndGun")
+                else if (curModName == "RunAndGun")
                     RunAndGun = true;
-                else if (curMod.Name == "Faction Discovery")
+                else if (curModName == "Faction Discovery")
                     FactionDiscovery = true;
-                else if (curMod.Name == "What the hack?!")
+                else if (curModName == "What the hack?!")
                     WhatTheHack = true;
-                else if (curMod.Name == "Combat Extended")
+                else if (curModName == "Combat Extended")
                     CombatExtended = true;
-                else if (curMod.Name == "Humanoid Alien Races" || curMod.Name == "Humanoid Alien Races ~ Dev")
+                else if (curModName == "Humanoid Alien Races" || curModName == "Humanoid Alien Races ~ Dev")
                     HumanAlienRace = true;
+                else if (curModName == "Vanilla Factions Expanded - Mechanoids")
+                    VFEMechanoids = true;
             }
         }
     }


### PR DESCRIPTION
Lots of VFE mechanoid patches are running even if you don't use that mod. Regardless of how lightweight the patches themselves may be, they would still add detour overhead to the methods of which are running constantly.

- These changes gate the patches to only apply on game startup if relevant.
- Added a check to see if the mod is active and applied it to other checks throughout the code that do the same, to unify it.
- Also a small optimization to ModCompatibilityCheck's startup impact

It may be good to have Taranchuk sign off on this one as, afaik, those harmony patches belong to him. I skimmed them over but as far as I could see they would be fine to omit when VFEM isn't active.