### PR TITLE
Fix NRE in RockUtility.PossibleRockTypesFor

### DIFF
--- a/Source/VFECore/VFECore/Utilities/RockUtility.cs
+++ b/Source/VFECore/VFECore/Utilities/RockUtility.cs
@@ -55,7 +55,10 @@ namespace VFECore
             return source.Where(item => !toExclude.Contains(item));
         }
 
-        public static IEnumerable<ThingDef> PossibleRockTypesFor(this BiomeDef biome, World world) =>
-            allNaturalRockDefs(world).Exclude(biome.DisallowedRocksFor());
+        public static IEnumerable<ThingDef> PossibleRockTypesFor(this BiomeDef biome, World world)
+        {
+            allNaturalRockDefs(world) ??= DefDatabase<ThingDef>.AllDefs.Where(d => d.IsNonResourceNaturalRock).ToList();
+            return allNaturalRockDefs(world).Exclude(biome.DisallowedRocksFor());
+        }
     }
 }


### PR DESCRIPTION
Currently the method `RockUtility.PossibleRockTypesFor` relies on `World.allNaturalRockDefs` being initialized. However, there are mods that add a prefix to `World.NaturalRockTypesIn` to override the result, such as "Configurable Maps" and "World Edit".

In that case, the vanilla code is skipped and `World.allNaturalRockDefs` is never initialized.
This results in an NRE in `RockUtility.PossibleRockTypesFor` and causes map generation to fail, and the world map UI to freeze.

This PR makes `RockUtility.PossibleRockTypesFor` more resilient against this kind of mod compatibility issue, by ensuring `World.allNaturalRockDefs` is initialized before it is used.

Side note: Alpha Biomes started using the affected code in its latest update, and is often used together with the mentioned mods, which is why this issue pops up often in reports now.

