### PR TITLE
Allow custom snow radius and depth for ability shoot projectile snow

### DIFF
--- a/Source/VFECore/Abilities/Abilities/Ability_ShootProjectile.cs
+++ b/Source/VFECore/Abilities/Abilities/Ability_ShootProjectile.cs
@@ -42,12 +42,14 @@
 
     public class Ability_ShootProjectile_Snow : Ability_ShootProjectile
     {
+        public float snowRadius = 3f;
+        public float snowDepth = 1f;
         public override void TargetEffects(params GlobalTargetInfo[] targetInfos)
         {
             base.TargetEffects(targetInfos);
             foreach (GlobalTargetInfo targetInfo in targetInfos)
             {
-                SnowUtility.AddSnowRadial(targetInfo.Cell, this.pawn.Map, 3f, 1f);
+                SnowUtility.AddSnowRadial(targetInfo.Cell, this.pawn.Map, this.snowRadius, this.snowDepth);
             }
         }
     }

--- a/Source/VFECore/Abilities/Abilities/Ability_ShootProjectile.cs
+++ b/Source/VFECore/Abilities/Abilities/Ability_ShootProjectile.cs
@@ -40,16 +40,21 @@
         public ThingDef projectile;
     }
 
-    public class Ability_ShootProjectile_Snow : Ability_ShootProjectile
+    public class Ability_ShootProjectile_Snow_Def : AbilityDef
     {
         public float snowRadius = 3f;
         public float snowDepth = 1f;
+    }
+
+    public class Ability_ShootProjectile_Snow : Ability_ShootProjectile
+    {
         public override void TargetEffects(params GlobalTargetInfo[] targetInfos)
         {
             base.TargetEffects(targetInfos);
+            var snowDef = (Ability_ShootProjectile_Snow_Def)this.def;
             foreach (GlobalTargetInfo targetInfo in targetInfos)
             {
-                SnowUtility.AddSnowRadial(targetInfo.Cell, this.pawn.Map, this.snowRadius, this.snowDepth);
+                SnowUtility.AddSnowRadial(targetInfo.Cell, this.pawn.Map, snowDef.snowRadius, snowDef.snowDepth);
             }
         }
     }

--- a/Source/VFECore/Abilities/Abilities/Ability_ShootProjectile.cs
+++ b/Source/VFECore/Abilities/Abilities/Ability_ShootProjectile.cs
@@ -40,10 +40,10 @@
         public ThingDef projectile;
     }
 
-    public class Ability_ShootProjectile_Snow_Def : AbilityDef
+    public class AbilityExtension_ShootProjectile_Snow : DefModExtension
     {
-        public float snowRadius = 3f;
-        public float snowDepth = 1f;
+        public float radius = 3f;
+        public float depth = 1f;
     }
 
     public class Ability_ShootProjectile_Snow : Ability_ShootProjectile
@@ -51,10 +51,10 @@
         public override void TargetEffects(params GlobalTargetInfo[] targetInfos)
         {
             base.TargetEffects(targetInfos);
-            var snowDef = (Ability_ShootProjectile_Snow_Def)this.def;
+            var snow = this.def.GetModExtension<AbilityExtension_ShootProjectile_Snow>();
             foreach (GlobalTargetInfo targetInfo in targetInfos)
             {
-                SnowUtility.AddSnowRadial(targetInfo.Cell, this.pawn.Map, snowDef.snowRadius, snowDef.snowDepth);
+                SnowUtility.AddSnowRadial(targetInfo.Cell, this.pawn.Map, snow?.radius ?? 3f, snow?.depth ?? 1f);
             }
         }
     }


### PR DESCRIPTION
Creates `AbilityExtension_ShootProjectile_Snow` which can be used in XML to customize the snow radius and depth.

Let me know what you think of this change. I'm thinking RWoM will need it for the snowball ability. I might have to do C# for that ability though anyway.