### PR TITLE
Fix compatibility issues due to ModsConfig.IsActive

### DIFF
--- a/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MechanoidsObeyOrders.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Mechanoids/MechanoidsObeyOrders.cs
@@ -159,7 +159,7 @@ namespace VFE.Mechanoids.HarmonyPatches
 		public static bool SimpleSidearmsActive;
 		static SimpleSidearmsPatch()
 		{
-			SimpleSidearmsActive = ModsConfig.IsActive("PeteTimesSix.SimpleSidearms");
+			SimpleSidearmsActive = ModsConfig.IsActive("PeteTimesSix.SimpleSidearms") || ModsConfig.IsActive("PeteTimesSix.SimpleSidearms_steam");
 			if (SimpleSidearmsActive)
 			{
 				var type = AccessTools.TypeByName("PeteTimesSix.SimpleSidearms.Extensions");

--- a/Source/VFECore/VFECore/HarmonyPatches/Projectile_Patches.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/Projectile_Patches.cs
@@ -16,7 +16,7 @@ namespace VFECore
     [HarmonyPatch]
     public static class VehicleFramework_Turret_Patch
     {
-        public static bool VFLoaded = ModsConfig.IsActive("SmashPhil.VehicleFramework");
+        public static bool VFLoaded = ModsConfig.IsActive("SmashPhil.VehicleFramework") || ModsConfig.IsActive("SmashPhil.VehicleFramework_steam");
         public static MethodInfo targetMethod;
         public static MethodInfo maxRangeInfo;
         public static MethodInfo turretLocation;


### PR DESCRIPTION
The issue occurs when checking if a mod is active with `ModsConfig.IsActive` when running the workshop version of a mod while there's a local copy in the mods directory. In those cases the `ModsConfig.IsActive` will return false as the running mod will have the `_steam` postfix.

The simple fix is to simply check for mod ID, as well as the mod ID with the `_steam` postfix.