### PR TITLE
Fix WeatherOverlay_Effects with multiple maps

### DIFF
--- a/Source/VFECore/VFECore/WeatherOverlays/WeatherOverlay_Effects.cs
+++ b/Source/VFECore/VFECore/WeatherOverlays/WeatherOverlay_Effects.cs
@@ -7,7 +7,7 @@ namespace VFECore
 {
     internal class WeatherOverlay_Effects : SkyOverlay
     {
-        public int nextDamageTick;
+        public Dictionary<Map, int> nextDamageTickForMap = new();
         public override void TickOverlay(Map map)
         {
             base.TickOverlay(map);
@@ -20,14 +20,16 @@ namespace VFECore
             {
                 if (options.activeOnWeatherPerceived is null || map.weatherManager.CurWeatherPerceived == options.activeOnWeatherPerceived)
                 {
+                    // If not in dictionary will fallback to default(int) - 0
+                    nextDamageTickForMap.TryGetValue(map, out var nextDamageTick);
                     if (nextDamageTick == 0 || (Find.TickManager.TicksGame - nextDamageTick) > options.ticksInterval.max)
                     {
-                        nextDamageTick = NextDamageTick(options);
+                        nextDamageTickForMap[map] = nextDamageTick = NextDamageTick(options);
                     }
                     if (Find.TickManager.TicksGame > nextDamageTick)
                     {
                         DoDamage(options, map);
-                        nextDamageTick = NextDamageTick(options);
+                        nextDamageTickForMap[map] = NextDamageTick(options);
                     }
                 }
             }


### PR DESCRIPTION
`WeatherOverlay_Effects` is keeping `nextDamageTick` as an int. However, there's 1 shared instance of `SkyOverlay` (or its subtype) for each `WeatherDef`.

This presents the issue where 1 map will set `nextDamageTick` to a value it'll use, and all maps processed after it will be ignored due to the value being set by a previous map.

The fix here is to store the next tick on a per-map basis using a dictionary. The value is then retrieved using `Dictionary.TryGetValue` (value will fallback to default of 0).