### PR TITLE
GeneUtils - include gene's defName in the error log

### DIFF
--- a/Source/VFECore/Genes/Harmony/GeneUtils.cs
+++ b/Source/VFECore/Genes/Harmony/GeneUtils.cs
@@ -128,7 +128,7 @@ namespace VanillaGenesExpanded
             }
             catch (Exception ex)
             {
-                Log.Error("[VEF] Error in GeneUtils.ApplyGeneEffects: " + ex);
+                Log.Error($"[VEF] Error in GeneUtils.ApplyGeneEffects for gene {gene?.def?.defName.ToStringSafe()}: {ex}");
             }
         }
 
@@ -248,7 +248,7 @@ namespace VanillaGenesExpanded
             }
             catch (Exception ex)
             {
-                Log.Error("[VEF] Error in GeneUtils.RemoveGeneEffects: " + ex);
+                Log.Error($"[VEF] Error in GeneUtils.RemoveGeneEffects for gene {gene?.def?.defName.ToStringSafe()}: {ex}");
             }
         }
     }


### PR DESCRIPTION
This should be useful when trying to figure out what specifically is breaking in the game. This can be especially in case issues appear when the stack trace is not providing useful info on what the culprit may be.