### PR TITLE
Update AbilityPawnFlyer to 1.5

### DIFF
--- a/Source/VFECore/Abilities/AbilityPawnFlyer.cs
+++ b/Source/VFECore/Abilities/AbilityPawnFlyer.cs
@@ -1,60 +1,25 @@
-﻿namespace VFECore.Abilities
+﻿using HarmonyLib;
+
+namespace VFECore.Abilities
 {
-    using System.Collections;
-    using System.Collections.Generic;
-    using HarmonyLib;
     using RimWorld;
     using RimWorld.Planet;
-    using UnityEngine;
     using Verse;
-    using Verse.Sound;
 
     public class AbilityPawnFlyer : PawnFlyer
     {
+        private static readonly AccessTools.FieldRef<PawnFlyer, IntVec3> DestCellField
+            = AccessTools.FieldRefAccess<IntVec3>(typeof(PawnFlyer), "destCell");
+
         public Abilities.Ability ability;
 
-        protected Vector3 position;
-        public    Vector3 target;
-
-        public Rot4 direction;
-
-        public override void SpawnSetup(Map map, bool respawningAfterLoad)
-        {
-            base.SpawnSetup(map, respawningAfterLoad);
-            this.direction = this.startVec.x > this.target.ToIntVec3().x ? Rot4.West :
-                             this.startVec.x < this.target.ToIntVec3().x ? Rot4.East :
-                             this.startVec.y < this.target.ToIntVec3().y ? Rot4.North :
-                                                                           Rot4.South;
-            float progress = (float)this.ticksFlying / (float)this.ticksFlightTime;
-            this.position = Vector3.Lerp(this.startVec, this.target, progress) + new Vector3(0f, 0f, 2f) * GenMath.InverseParabola(progress);
-        }
-
-        public override void Tick()
-        {
-            float progress = (float) this.ticksFlying / (float) this.ticksFlightTime;
-            this.position = Vector3.Lerp(this.startVec, this.target, progress) + new Vector3(0f, 0f, 2f) * GenMath.InverseParabola(progress);
-
-
-            IList value = Traverse.Create(this.FlyingPawn.Drawer.renderer).Field("effecters").Field("pairs").GetValue() as IList;
-            foreach (object o in value)
-                Traverse.Create(o).Field("effecter").GetValue<Effecter>().EffectTick(new TargetInfo(this.position.ToIntVec3(), this.Map), TargetInfo.Invalid);
-
-            base.Tick();
-        }
-
-        public override void DynamicDrawPhaseAt(DrawPhase phase, Vector3 drawLoc, bool flip = false)
-        {
-            this.FlyingPawn.Rotation = this.Rotation = this.direction;
-            base.DynamicDrawPhaseAt(phase, this.position, flip);
-        }
+        public ref IntVec3 DestinationCell => ref DestCellField(this);
 
         protected override void RespawnPawn()
         {
-            this.Position = this.target.ToIntVec3();
-            LandingEffects();
             Pawn pawn = this.FlyingPawn;
             base.RespawnPawn();
-            if (this.ability != null)
+            if (pawn != null && this.ability != null)
             {
                 this.ability.ApplyHediffs(new GlobalTargetInfo(pawn));
 
@@ -67,19 +32,10 @@
             }
         }
 
-        protected virtual void LandingEffects()
-        {
-            if (soundLanding != null)
-            {
-                soundLanding.PlayOneShot(new TargetInfo(base.Position, base.Map));
-            }
-        }
-
         public override void ExposeData()
         {
             base.ExposeData();
             Scribe_References.Look(ref this.ability, nameof(this.ability));
-            Scribe_Values.Look(ref this.direction, nameof(this.direction));
         }
     }
 }


### PR DESCRIPTION
The `PawnFlyer` received some substantial changes in 1.5, specifically - `PawnJumper` (previously DLC only feature) was (basically) merged with `PawnFlyer`, no longer locking any of its features behind DLC, along with a multitude of other changes/improvements. Because of this, some of the changes in this PR will break existing mods and require them to update their implementations. Because the 1.5 update is not yet officially release, I felt that it's the perfect moment to introduce changes such as these. All the changes I've introduced, as well as extra details and explanations are below.

&nbsp;

Traverse to access effecters was removed:
- It's no longer needed as vanilla now uses `DrawPosHeld` instead of `DrawPos` for its `SubEffecter` classes
  - If a mod is still using `DrawPos` for its `SubEffecter` classes then they should be updated, as they will cause issues with vanilla/other modded flyers as well
- The patch was not really working properly for the most part
  - This is due to vanilla code for the effecters still running (it was running before the one included here), and some `SubEffecter` classes only allowing for spawning motes every X ticks - only allowing them to spawn in the wrong position
- Traverse is a very slow approach (slightly slower than a pure reflection approach), and should have been replaced by a different one

&nbsp;

Position calculations were removed:
- Vanilla now calculates position in `DrawPos` - it can be changed in several ways:
  - Make a custom `Verse.PawnFlyerWorker` subclass in C# (XML path: `Defs\ThingDef\pawnFlyer\workerClass`, C# location: `Verse.PawnFlyerProperties.workerClass`)
  - Override `DrawPos` property in C#
- The way vanilla handles those calculations is better for performance, only recalculating the position once a tick if the pawn is being drawn (instead of each tick, even if not drawn)

&nbsp;

Property for accessing `destCell` field:
- The field is private in the game at the moment.
- While not used by the type itself, other types inheriting from it may find it useful
- Uses Harmony's `FieldRef`, so it should be fairly fast (especially when compared to operating on `FieldInfo` or using Harmony's `Traverse`)
  - The `FieldRef` is stored as a static field in `AbilityPawnFlyer` itself, but could be moved outside if needed
- It's a ref getter, so it's possible to both read and modify the field
  - Alternatively this could be implemented as a getter/setter without the use of references if desired
- There's several other private fields - they could also be exposed like that, however I've decided that destination position may be the most useful one

&nbsp;

Pawn respawn changes:
- Setting of position before spawning no longer required, vanilla code uses target position instead
- Removed `LandingEffects`/playing of `soundLanding` sound, as vanilla will do it now
- A non-null check for pawn added
  - The vanilla flyer now supports flying `Thing`, which doesn't necessarily have to be a pawn

&nbsp;

Forced direction removed:
- From my testing it was not needed, possibly due to 1.5 changes.
  - If it's really needed for something, then I can restore.

&nbsp;

Save/reload bug fixed:
- In 1.4 (and earlier) saving and reloading caused each flying pawn to fly towards the (0,0) cell
- This was caused by not using the vanilla's target cell field, instead adding a new field (which was then never exposed, causing the bug)
- It should no longer be relevant as the code now uses the vanilla's target cell field, which vanilla properly exposes