### PR TITLE
Update AbilityPawnFlyer to allow custom drawing positions

### DIFF
--- a/Source/VFECore/Abilities/AbilityPawnFlyer.cs
+++ b/Source/VFECore/Abilities/AbilityPawnFlyer.cs
@@ -1,19 +1,45 @@
-﻿using HarmonyLib;
-
-namespace VFECore.Abilities
+﻿namespace VFECore.Abilities
 {
+    using HarmonyLib;
     using RimWorld;
     using RimWorld.Planet;
+    using UnityEngine;
     using Verse;
 
     public class AbilityPawnFlyer : PawnFlyer
     {
         private static readonly AccessTools.FieldRef<PawnFlyer, IntVec3> DestCellField
             = AccessTools.FieldRefAccess<IntVec3>(typeof(PawnFlyer), "destCell");
+        private static readonly AccessTools.FieldRef<PawnFlyer, Vector3> EffectivePosField
+            = AccessTools.FieldRefAccess<Vector3>(typeof(PawnFlyer), "effectivePos");
+        private static readonly AccessTools.FieldRef<PawnFlyer, Vector3> GroundPosField
+            = AccessTools.FieldRefAccess<Vector3>(typeof(PawnFlyer), "groundPos");
+        private static readonly AccessTools.FieldRef<PawnFlyer, float> EffectiveHeightField
+            = AccessTools.FieldRefAccess<float>(typeof(PawnFlyer), "effectiveHeight");
 
-        public Abilities.Ability ability;
+        public Ability ability;
 
         public ref IntVec3 DestinationCell => ref DestCellField(this);
+
+        /// <summary>
+        /// Used as the position of the flying pawn and the pawn/thing they are carrying.
+        /// </summary>
+        public ref Vector3 EffectivePos => ref EffectivePosField(this);
+        /// <summary>
+        /// Used as the position of the flying pawn's shadow.
+        /// </summary>
+        public ref Vector3 GroundPos => ref GroundPosField(this);
+        /// <summary>
+        /// Used as the size of the flying pawn's shadow (clamped to 0-1, bigger value means smaller shadow).
+        /// </summary>
+        public ref float EffectiveHeight => ref EffectiveHeightField(this);
+
+        /// <summary>
+        /// Used to replace vanilla position calculation.
+        /// Use <see cref="EffectivePos"/>, <see cref="GroundPos"/>, and <see cref="EffectiveHeight"/> to achieve this.
+        /// </summary>
+        /// <returns>true if the vanilla RecomputePosition method should be cancelled, or false if it should run normally.</returns>
+        protected internal virtual bool CustomRecomputePosition() => false;
 
         protected override void RespawnPawn()
         {

--- a/Source/VFECore/Abilities/PawnFlyer_RecomputePosition_Patch.cs
+++ b/Source/VFECore/Abilities/PawnFlyer_RecomputePosition_Patch.cs
@@ -1,0 +1,11 @@
+﻿using HarmonyLib;
+using RimWorld;
+
+namespace VFECore.Abilities;
+
+[HarmonyPatch(typeof(PawnFlyer), "RecomputePosition")]
+public static class PawnFlyer_RecomputePosition_Patch
+{
+    // Replace the vanilla method if the flyer is AbilityPawnFlyer and returned true.
+    public static bool Prefix(PawnFlyer __instance) => __instance is not AbilityPawnFlyer flyer || !flyer.CustomRecomputePosition();
+}


### PR DESCRIPTION
My previous PR was incorrect in that overriding `DrawPos` would be enough to achieve custom drawing position (without using `PawnFlyerWorker`), as vanilla code uses its private fields for it.

This PR allows for implementing custom drawing position due to:
- Exposing private fields
  - `EffectivePos` is used for the flying pawn's position, as well as the carried thing's position
  - `GroundPos` and `EffectiveHeight` are used for shadow drawing
- Adding a virtual method `CustomRecomputePosition`
  - When returning `false`, the vanilla code will calculate position (using `PawnFlyerWorker`)
  - When returning `true`, the vanilla code won't run and instead the positions need to be set in this method