### PR TITLE
Modify abilities to allow casting them while carrying things/pawns

### DIFF
--- a/1.5/Defs/Abilities/GeneralAbilityDefs.xml
+++ b/1.5/Defs/Abilities/GeneralAbilityDefs.xml
@@ -8,6 +8,7 @@
     <collideWithPawns>true</collideWithPawns>
     <playerInterruptible>false</playerInterruptible>
     <suspendable>false</suspendable>
+    <carryThingAfterJob>true</carryThingAfterJob>
   </JobDef>
 
 
@@ -15,6 +16,7 @@
     <defName>VFEA_UseAbility</defName>
     <driverClass>VFECore.Abilities.JobDriver_CastAbilityOnce</driverClass>
     <allowOpportunisticPrefix>true</allowOpportunisticPrefix>
+    <carryThingAfterJob>true</carryThingAfterJob>
   </JobDef>
   
 
@@ -22,12 +24,14 @@
     <defName>VFEA_GotoTargetAndUseAbility</defName>
     <driverClass>VFECore.Abilities.JobDriver_GotoTargetAndCastAbilityOnce</driverClass>
     <allowOpportunisticPrefix>true</allowOpportunisticPrefix>
+    <carryThingAfterJob>true</carryThingAfterJob>
   </JobDef>
   
   <JobDef>
   	<defName>VFEA_StandAndFaceTarget</defName>
   	<driverClass>VFECore.Abilities.JobDriver_StandAndFaceTarget</driverClass>
   	<reportString>standing.</reportString>
+    <carryThingAfterJob>true</carryThingAfterJob>
   </JobDef>
 
   <ThingDef ParentName="PawnFlyerBase">

--- a/Source/VFECore/Abilities/Ability.cs
+++ b/Source/VFECore/Abilities/Ability.cs
@@ -442,7 +442,7 @@
             ModifyTargets(ref targets);
             comp.currentlyCastingTargets = targets;
             if (this.pawn.IsCaravanMember()) this.Cast(targets);
-            else this.pawn.jobs.StartJob(job, JobCondition.InterruptForced);
+            else this.pawn.jobs.StartJob(job, JobCondition.InterruptForced, keepCarryingThingOverride: def.keepCarryingThing);
         }
 
         protected bool currentAoETargeting;

--- a/Source/VFECore/Abilities/AbilityDef.cs
+++ b/Source/VFECore/Abilities/AbilityDef.cs
@@ -14,6 +14,7 @@ namespace VFECore.Abilities
         public bool needsTicking;
         public bool showUndrafted;
         public bool? isPositive;
+        public bool? keepCarryingThing;
 
         public HediffWithLevelCombination requiredHediff;
         public TraitDef                   requiredTrait;


### PR DESCRIPTION
This PR allows for abilities to be cast while carrying a thing/pawn. This is fully optional.

- `AbilityDef` received a new field `bool? keepCarryingThing`
  - When the value is default (`null`) the carrying functionality will be determined by the casting `JobDef` (drop)
  - When set to either `true` or `false`, the functionality will be forced to carry/drop, despite what the `JobDef` defines
- The value will be used when starting a job (as the `keepCarryingThingOverride` argument)
- All the ability casting `JobDef`s had `carryThingAfterJob` set to true
  - This will have no effect if the pawn wasn't carrying anything once the job ended - They would have dropped whatever they were carrying at the start of the job anyway, unless the earlier mentioned value in `AbilityDef` was set to `true`
  - If a job was started while carrying something, this will stop the casting pawn from dropping the carried pawn/thing once the job ends