### PR TITLE
Fix PawnFlyer_RecomputePosition_Patch not being compiled

### DIFF
--- a/Source/VFECore/VFECore.csproj
+++ b/Source/VFECore/VFECore.csproj
@@ -418,6 +418,7 @@
     <Compile Include="Abilities\ModExtensions\AbilityExtension_SocialInteraction.cs" />
     <Compile Include="Abilities\ModExtensions\AbilityExtension_WarmupEffecter.cs" />
     <Compile Include="Abilities\PawnFlyer_MakeFlyer_Patch.cs" />
+    <Compile Include="Abilities\PawnFlyer_RecomputePosition_Patch.cs" />
     <Compile Include="Abilities\PawnGen_Patch.cs" />
     <Compile Include="Abilities\PawnKindAbilityExtension.cs" />
     <Compile Include="Abilities\TryGetAttackVerb_Patch.cs" />


### PR DESCRIPTION
In #86 I've included `PawnFlyer_RecomputePosition_Patch` class, but haven't realized the project is not configured to automatically compile all files. This PR should fix where this file is not compiled by including it in .csproj file.