### PR TITLE
Automatically re-select flying pawns (AbilityPawnFlyer)

### DIFF
--- a/Source/VFECore/Abilities/AbilityPawnFlyer.cs
+++ b/Source/VFECore/Abilities/AbilityPawnFlyer.cs
@@ -18,6 +18,7 @@
             = AccessTools.FieldRefAccess<float>(typeof(PawnFlyer), "effectiveHeight");
 
         public Ability ability;
+        public bool selectOnSpawn = false;
 
         public ref IntVec3 DestinationCell => ref DestCellField(this);
 
@@ -40,6 +41,26 @@
         /// </summary>
         /// <returns>true if the vanilla RecomputePosition method should be cancelled, or false if it should run normally.</returns>
         protected internal virtual bool CustomRecomputePosition() => false;
+
+        /// <summary>
+        /// Used to check if the pawn should be re-selected when spawning a new flyer.
+        /// The flyer is not yet initialized at this point, with only its constructor being called.
+        /// </summary>
+        /// <param name="target">The pawn for which this flyer is being created for.</param>
+        /// <returns>True if the pawn should be automatically reselected, false otherwise.</returns>
+        protected internal virtual bool AutoSelectPawn(Pawn target) => true;
+
+        public override void SpawnSetup(Map map, bool respawningAfterLoad)
+        {
+            base.SpawnSetup(map, respawningAfterLoad);
+
+            if (selectOnSpawn)
+            {
+                selectOnSpawn = false;
+                // Select the flying thing (pawn), with the flyer itself as fallback
+                Find.Selector.Select(FlyingThing ?? this);
+            }
+        }
 
         protected override void RespawnPawn()
         {

--- a/Source/VFECore/Abilities/PawnFlyer_MakeFlyer_Patch.cs
+++ b/Source/VFECore/Abilities/PawnFlyer_MakeFlyer_Patch.cs
@@ -33,6 +33,17 @@
                 {
                     //do nothing or nop
                 }
+                else if (codes[i].opcode == OpCodes.Stloc_0)
+                {
+                    // We check for Stloc_0, as the flyer is only assigned to it once in the code
+                    yield return codes[i];
+                    // Load the flyer
+                    yield return CodeInstruction.LoadLocal(0);
+                    // Load the pawn
+                    yield return CodeInstruction.LoadArgument(1);
+                    // Call our method
+                    yield return CodeInstruction.Call(typeof(PawnFlyer_MakeFlyer_Patch), nameof(SetSelectOnSpawn));
+                }
                 else
                 {
                     yield return codes[i];
@@ -46,6 +57,11 @@
                 return true;
             }
             return false;
+        }
+        public static void SetSelectOnSpawn(PawnFlyer flyer, Pawn pawn)
+        {
+            if (flyer is AbilityPawnFlyer abilityFlyer && Find.Selector.IsSelected(pawn) && abilityFlyer.AutoSelectPawn(pawn))
+                abilityFlyer.selectOnSpawn = true;
         }
     }
 }


### PR DESCRIPTION
In vanilla, whenever a pawn is flying/jumping they are automatically re-selected when they get despawned and their flyer gets spawned.

Those changes should bring this behaviour to all flyers using `AbilityPawnFlyer`. Changes made to achieve this:
- `PawnFlyer_MakeFlyer_Patch` was modified to (right after the flyer was constructed) check if it's `AbilityPawnFlyer` and the pawn was selected
  - If successful, it then check if the pawn should be selected by calling `AbilityPawnFlyer.AutoSelectPawn` (true by default), which other mods can change to configure their auto-selection behavior
  - It then sets the field `AbilityPawnFlyer.selectOnSpawn` to true
- During a call to `AbilityPawnFlyer.SpawnSetup` the value of `selectOnSpawn` will be checked
  - If it's true, the pawn (`FlyingThing` property) will be selected
  - If the pawn is null, it'll select the flyer itself as a fallback

Please note, some of the mods that are already using `AbilityPawnFlyer` may need to be recompiled. This is due to their `base.SpawnSetup` call potentially calling `PawnFlyer.SpawnSetup` instead of `AbilityPawnFlyer.SpawnSetup`. This affects Vanilla Factions Expanded - Pirates and potentially other mods.