### PR TITLE
added null check to solve compatibility problem

### DIFF
--- a/Source/MVCF/Utilities/DrawUtility.cs
+++ b/Source/MVCF/Utilities/DrawUtility.cs
@@ -32,7 +32,7 @@ public static class DrawUtility
         if (parms.shrunk) return false;
         if (command is not Command_VerbTarget gizmo) return false;
         var verb = gizmo.verb;
-        if (!verb.CasterIsPawn) return false;
+        if (verb == null || !verb.CasterIsPawn) return false;
         var pawn = verb.CasterPawn;
         if (pawn.Faction != Faction.OfPlayer) return false;
         var man = verb.Managed(false);


### PR DESCRIPTION
Greetings. Our MIS group used some special ways to write skills of mobile game Arknights. One of which is that we wrote a 
child of Command_VerbTarget without verb, which caused incompatibility.