### PR TITLE
Support non-Thing targets in GotoTargetAndCastAbility

### DIFF
--- a/Source/VEF/Abilities/AI/JobDrivers/JobDriver_GotoTargetAndCastAbilityOnce.cs
+++ b/Source/VEF/Abilities/AI/JobDrivers/JobDriver_GotoTargetAndCastAbilityOnce.cs
@@ -39,16 +39,16 @@
             };
             toil.tickAction = delegate
             {
-                Thing target = job.targetA.Thing;
+                IntVec3 target = job.targetA.Cell;
                 pawn.rotationTracker.FaceTarget(target);
                 Map map = pawn.Map;
-                if (GenSight.LineOfSight(pawn.Position, target.Position, map, skipFirstCell: true) 
-                    && pawn.Position.DistanceTo(target.Position) <= CompAbilities.currentlyCasting.def.distanceToTarget
+                if (GenSight.LineOfSight(pawn.Position, target, map, skipFirstCell: true)
+                    && pawn.Position.DistanceTo(target) <= CompAbilities.currentlyCasting.def.distanceToTarget
                     && (!pawn.pather.Moving || pawn.pather.nextCell.GetDoor(map) == null))
                 {
                     pawn.pather.StopDead();
                     pawn.rotationTracker.FaceTarget(target);
-                    if (target is Pawn victim)
+                    if (job.TargetA.Thing is Pawn victim)
                     {
                         victim.jobs.TryTakeOrderedJob(JobMaker.MakeJob(VFE_DefOf_Abilities.VFEA_StandAndFaceTarget, pawn));
                     }
@@ -65,9 +65,9 @@
                         IntVec3 intVec = IntVec3.Invalid;
                         for (int i = 0; i < 9 && (i != 8 || !intVec.IsValid); i++)
                         {
-                            IntVec3 intVec2 = target.Position + GenAdj.AdjacentCellsAndInside[i];
+                            IntVec3 intVec2 = target + GenAdj.AdjacentCellsAndInside[i];
                             if (intVec2.InBounds(map) && intVec2.Walkable(map) && intVec2 != pawn.Position &&
-                            SocialInteractionUtility.IsGoodPositionForInteraction(intVec2, target.Position, map)
+                            SocialInteractionUtility.IsGoodPositionForInteraction(intVec2, target, map)
                             && pawn.CanReach(intVec2, PathEndMode.OnCell, Danger.Deadly)
                             && (!intVec.IsValid || pawn.Position.DistanceToSquared(intVec2) < pawn.Position.DistanceToSquared(intVec)))
                             {


### PR DESCRIPTION
Couldn't manage to build the project so a maintainer would have to create the new assembly, but compiles and tested in my own project:
https://github.com/Toby222/vpe-better-autocast/blob/3ea7b44cb83ef592338fceb850648d16f0ec27e9/Source/JobDrivers/JobDriver_GotoLocationAndCastAbilityOnce.cs