### PR TITLE
Compatibility with Dual Wield 1.5

### DIFF
--- a/Source/MVCF/PatchSets/PatchSet_DualWield.cs
+++ b/Source/MVCF/PatchSets/PatchSet_DualWield.cs
@@ -8,7 +8,7 @@ public class PatchSet_DualWield : PatchSet
 {
     public override IEnumerable<Patch> GetPatches()
     {
-        yield return Patch.Transpiler(AccessTools.Method(AccessTools.TypeByName("DualWield.Harmony.PawnRenderer_RenderPawnAt"), "Postfix"),
+        yield return Patch.Transpiler(AccessTools.Method(AccessTools.TypeByName("DualWield.HarmonyInstance.PawnRenderer_RenderPawnAt"), "Postfix"),
             AccessTools.Method(GetType(), nameof(AddNullCheck)));
     }
 

--- a/Source/VFECore/VFECore/HarmonyPatches/HarmonyPatches.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/HarmonyPatches.cs
@@ -27,12 +27,12 @@ namespace VFECore
             // Dual Wield
             if (ModCompatibilityCheck.DualWield)
             {
-                var addHumanlikeOrdersPatch = GenTypes.GetTypeInAnyAssembly("DualWield.Harmony.FloatMenuMakerMap_AddHumanlikeOrders", "DualWield.Harmony");
+                var addHumanlikeOrdersPatch = GenTypes.GetTypeInAnyAssembly("DualWield.HarmonyInstance.FloatMenuMakerMap_AddHumanlikeOrders", "DualWield.HarmonyInstance");
                 if (addHumanlikeOrdersPatch != null)
                     VFECore.harmonyInstance.Patch(AccessTools.Method(addHumanlikeOrdersPatch, "Postfix"),
                         transpiler: new HarmonyMethod(typeof(Patch_DualWield_Harmony_FloatMenuMakerMap_AddHumanlikeOrders.manual_Postfix), "Transpiler"));
                 else
-                    Log.Error("Could not find type DualWield.Harmony.FloatMenuMakerMap_AddHumanlikeOrders in Dual Wield");
+                    Log.Error("Could not find type DualWield.HarmonyInstance.FloatMenuMakerMap_AddHumanlikeOrders in Dual Wield");
 
                 // Taranchuk: no idea how to handle this
                 //var extEquipmentTracker = GenTypes.GetTypeInAnyAssembly("DualWield.Ext_Pawn_EquipmentTracker", "DualWield");

--- a/Source/VFECore/VFECore/HarmonyPatches/ModCompatibility/DualWield/Patch_DualWield_Harmony_FloatMenuMakerMap_AddHumanlikeOrders.cs
+++ b/Source/VFECore/VFECore/HarmonyPatches/ModCompatibility/DualWield/Patch_DualWield_Harmony_FloatMenuMakerMap_AddHumanlikeOrders.cs
@@ -22,7 +22,7 @@ namespace VFECore
             public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
             {
                 #if DEBUG
-                    Log.Message("DualWield.Harmony.FloatMenuMakerMap_AddHumanlikeOrders.manual_Postfix transpiler start (1 match todo)");
+                    Log.Message("DualWield.HarmonyInstance.FloatMenuMakerMap_AddHumanlikeOrders.manual_Postfix transpiler start (1 match todo)");
                 #endif
 
 


### PR DESCRIPTION
In the 1.5 version of DualWield the DualWield.Harmony namespace changed to DualWield.HarmonyInstance.

I don't know how this will effect things if/when Tacticowl gets updated.

https://steamcommunity.com/sharedfiles/filedetails/?id=2537588364
