### PR TITLE
Added support for Pipe System resources to ItemProcessor.

### DIFF
--- a/Languages/English/Keyed/ItemProcessorBase.xml
+++ b/Languages/English/Keyed/ItemProcessorBase.xml
@@ -27,6 +27,7 @@
 	<IP_IngredientImproperlyDefined>One of the ingredients has been improperly defined to work with the item processor, contact the mod's author</IP_IngredientImproperlyDefined>
 	<IP_NoPowerDestroysWarning>{0} needs to be powered to start working</IP_NoPowerDestroysWarning>
 	<IP_NoFuelDestroysWarning>{0} needs to be fueled to start working</IP_NoFuelDestroysWarning>
+	<IP_NoResourceDestroysWarning>{0} needs required resource to start working</IP_NoResourceDestroysWarning>
 	<IP_LightDestroysWarning>{0} needs to have an adequate light level to start working</IP_LightDestroysWarning>
 	<IP_RainDestroysWarning>{0} needs to not be raining to start working</IP_RainDestroysWarning>
 	<IP_TemperatureDestroysWarning>{0} needs to have an adequate temperature ({1} - {2}) to start working</IP_TemperatureDestroysWarning>

--- a/Source/VFECore/ItemProcessor/Commands/Command_ItemLists.cs
+++ b/Source/VFECore/ItemProcessor/Commands/Command_ItemLists.cs
@@ -336,6 +336,10 @@ namespace ItemProcessor
                 {
                     Messages.Message("IP_NoFuelDestroysWarning".Translate(building.def.LabelCap), building, MessageTypeDefOf.NegativeEvent, true);
                 }
+                else if (building.compResourceTrader != null && !building.compResourceTrader.ResourceOn && building.compItemProcessor.Props.noPowerDestroysProgress)
+                {
+					Messages.Message("IP_NoResourceDestroysWarning".Translate(building.def.LabelCap), building, MessageTypeDefOf.NegativeEvent, true);
+				}
                 else
                 {
                     building.IngredientsChosenBringThemIn();
@@ -490,6 +494,10 @@ namespace ItemProcessor
                         {
                             Messages.Message("IP_NoFuelDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
                         }
+                        else if (processor.compResourceTrader != null && !processor.compResourceTrader.ResourceOn && processor.compItemProcessor.Props.noPowerDestroysProgress)
+                        {
+							Messages.Message("IP_NoResourceDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
+						}
                         else
                         {
                             processor.IngredientsChosenBringThemIn();
@@ -645,6 +653,10 @@ namespace ItemProcessor
                         {
                             Messages.Message("IP_NoFuelDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
                         }
+                        else if (processor.compResourceTrader != null && !processor.compResourceTrader.ResourceOn && processor.compItemProcessor.Props.noPowerDestroysProgress)
+                        {
+							Messages.Message("IP_NoResourceDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
+						}
                         else
                         {
                             processor.IngredientsChosenBringThemIn();
@@ -790,6 +802,10 @@ namespace ItemProcessor
                         {
                             Messages.Message("IP_NoFuelDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
                         }
+                        else if (processor.compResourceTrader != null && !processor.compResourceTrader.ResourceOn && processor.compItemProcessor.Props.noPowerDestroysProgress)
+                        {
+							Messages.Message("IP_NoResourceDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
+						}
                         else
                         {
                             processor.IngredientsChosenBringThemIn();
@@ -934,6 +950,10 @@ namespace ItemProcessor
                         {
                             Messages.Message("IP_NoFuelDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
                         }
+                        else if (processor.compResourceTrader != null && !processor.compResourceTrader.ResourceOn && processor.compItemProcessor.Props.noPowerDestroysProgress)
+                        {
+							Messages.Message("IP_NoResourceDestroysWarning".Translate(processor.def.LabelCap), processor, MessageTypeDefOf.NegativeEvent, true);
+						}
                         else
                         {
                             processor.IngredientsChosenBringThemIn();


### PR DESCRIPTION
Allows ItemProcessor.Building_ItemProcessor to use PipeSystem.CompResourceTrader in addition to default CompPowerTrader and CompRefuelable.

Posted about this on the VE Framework Workshop page about 2 years ago. Got a reply (Sarg?) saying a rewrite was planned, but it hasn't happened yet.

I have a mod planned that needs it (Helixien Gas Cooking, for the soup pot) that I've been sitting on for 2 years (I also stopped playing for a while as well, to be fair) and it would be cool to finally finish it.

Shows "Inspect string contains blank lines" error, but this also appears to occur when I revert my changes. Quick look on RimWorld Discord has reports of this, so fairly certain this isn't me.