### PR TITLE
Fix constant warning spam with CompShieldField caused by null HostFaction

### DIFF
--- a/Source/VFECore/VFECore/Comps/ThingComps/CompShieldField.cs
+++ b/Source/VFECore/VFECore/Comps/ThingComps/CompShieldField.cs
@@ -760,7 +760,7 @@ namespace VFECore
             }
             if (HostThing.Map != null)
             {
-                if ((GenHostility.AnyHostileActiveThreatTo(HostThing.Map, HostFaction)
+                if ((HostFaction != null && GenHostility.AnyHostileActiveThreatTo(HostThing.Map, HostFaction)
                     || HostThing.Map.listerThings.ThingsOfDef(VFEDefOf.Tornado).Any()
                     || HostThing.Map.listerThings.ThingsOfDef(RimWorld.ThingDefOf.DropPodIncoming).Any()) && shieldBuffer < 15)
                     shieldBuffer = 15;


### PR DESCRIPTION
The comp is currently calling `GenHostility.AnyHostileActiveThreatTo` using `HostFaction` property without checking if it's null or not. I've included a simple null check there to fix any problems.

Apparel doesn't have a faction, so when unequipped calls to `HostFaction` always have a null faction (since they use the wearer if equipped, the method should generally return a faction there). On top of that, if the comp is applied to a building, the building isn't guaranteed to have a faction either.

From what I saw, this affects Vanilla Races Expanded - Archon (specifically the archoplates). There may be other mods affected by this issue, but I haven't encountered any myself.