### PR TITLE
Genes can specify extra defs to treat as human meat/leather

### DIFF
--- a/Source/VFECore/Genes/DefModExtensions/GeneExtension.cs
+++ b/Source/VFECore/Genes/DefModExtensions/GeneExtension.cs
@@ -58,6 +58,10 @@ namespace VanillaGenesExpanded
         public ThingDef customMeatThingDef = null;
         //Custom leather thingDef when butchered
         public ThingDef customLeatherThingDef = null;
+        //List of foods considered human meat
+        public List<ThingDef> defsTreatedAsHumanMeat = null;
+        //List of stuff considered human leather
+        public List<ThingDef> defsTreatedAsHumanLeather = null;
 
         //Disease progression factor. Diseases will advance (when not immunized) by this factor
         public float diseaseProgressionFactor = 1f;

--- a/Source/VFECore/Genes/Harmony/FoodUtility_GetMeatSourceCategory.cs
+++ b/Source/VFECore/Genes/Harmony/FoodUtility_GetMeatSourceCategory.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace VanillaGenesExpanded;
+
+[HarmonyPatch(typeof(FoodUtility), nameof(FoodUtility.GetMeatSourceCategory))]
+public static class FoodUtility_GetMeatSourceCategory
+{
+    private static bool Prefix(ThingDef source, ref MeatSourceCategory __result)
+    {
+        // Source can't be null here.
+        if (ThingIngestingPatches.extraHumanMeatDefs != null &&
+            ThingIngestingPatches.extraHumanMeatDefs.Contains(source))
+        {
+            __result = MeatSourceCategory.Humanlike;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Source/VFECore/Genes/Harmony/FoodUtility_GetMeatSourceCategoryFromCorpse.cs
+++ b/Source/VFECore/Genes/Harmony/FoodUtility_GetMeatSourceCategoryFromCorpse.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace VanillaGenesExpanded;
+
+[HarmonyPatch(typeof(FoodUtility), nameof(FoodUtility.GetMeatSourceCategoryFromCorpse))]
+public static class FoodUtility_GetMeatSourceCategoryFromCorpse
+{
+    private static bool Prefix(Thing thing, ref MeatSourceCategory __result)
+    {
+        if (ThingIngestingPatches.extraHumanMeatDefs != null &&
+            thing is Corpse corpse &&
+            ThingIngestingPatches.extraHumanMeatDefs.Contains(corpse.InnerPawn.RaceProps.meatDef))
+        {
+            __result = MeatSourceCategory.Humanlike;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Source/VFECore/Genes/Harmony/ThingIngestingPatches.cs
+++ b/Source/VFECore/Genes/Harmony/ThingIngestingPatches.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace VanillaGenesExpanded;
+
+[HarmonyPatch]
+public static class ThingIngestingPatches
+{
+    public static Pawn pawn;
+    public static List<ThingDef> extraHumanMeatDefs;
+
+    private static IEnumerable<MethodBase> TargetMethods()
+    {
+        // Can't specify both using two [HarmonyPatch] attributes
+        // as it seems to bug out the patch and cause the __state
+        // to be shared between all the patched methods, rather
+        // than keeping it for the same method only. Using TargetMethods()
+        // or having two separate patch classes fixes that issue.
+        yield return AccessTools.DeclaredMethod(typeof(Thing), nameof(Thing.Ingested));
+        yield return AccessTools.DeclaredMethod(typeof(FoodUtility), nameof(FoodUtility.ThoughtsFromIngesting));
+    }
+
+    private static void Prefix(Pawn ingester, out bool __state)
+    {
+        // Only do the setup if a pawn wasn't setup earlier.
+        // This will handle situations where the methods
+        // are called recursively, or one calls the other.
+        if (pawn == null && ingester != null)
+        {
+            __state = true;
+            pawn = ingester;
+            StaticCollectionsClass.defs_treated_as_human_meat.TryGetValue(ingester, out extraHumanMeatDefs);
+        }
+        else
+        {
+            __state = false;
+        }
+    }
+
+    // Use finalizer over a postfix to ensure the cleanup always happens, even if we get exceptions
+    private static void Finalizer(bool __state)
+    {
+        if (__state)
+        {
+            pawn = null;
+            extraHumanMeatDefs = null;
+        }
+    }
+}

--- a/Source/VFECore/Genes/Harmony/ThoughtWorker_HumanLeatherApparel_CurrentThoughtState.cs
+++ b/Source/VFECore/Genes/Harmony/ThoughtWorker_HumanLeatherApparel_CurrentThoughtState.cs
@@ -1,0 +1,42 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace VanillaGenesExpanded;
+
+[HarmonyPatch(typeof(ThoughtWorker_HumanLeatherApparel), nameof(ThoughtWorker_HumanLeatherApparel.CurrentThoughtState))]
+public class ThoughtWorker_HumanLeatherApparel_CurrentThoughtState
+{
+    public static void Postfix(Pawn p, ref ThoughtState __result)
+    {
+        // Already maxed out
+        if (__result.StageIndex >= 4)
+            return;
+
+        // Only do anything if the pawn has custom leather defined
+        if (!StaticCollectionsClass.defs_treated_as_human_leather.TryGetValue(p, out var leathers))
+            return;
+
+        var stage = __result.StageIndex;
+        // If inactive the stage is -99999
+        if (stage < 0)
+            stage = 0;
+        var reason = __result.Reason;
+
+        foreach (var apparel in p.apparel.WornApparel)
+        {
+            if (apparel.Stuff != null && leathers.Contains(apparel.Stuff))
+            {
+                reason ??= apparel.def.label;
+                stage++;
+            }
+        }
+
+        __result = stage switch
+        {
+            0    => ThoughtState.Inactive,
+            >= 5 => ThoughtState.ActiveAtStage(4, reason),
+            _    => ThoughtState.ActiveAtStage(stage - 1, reason)
+        };
+    }
+}

--- a/Source/VFECore/Genes/Utils/GeneUtils.cs
+++ b/Source/VFECore/Genes/Utils/GeneUtils.cs
@@ -102,6 +102,14 @@ namespace VanillaGenesExpanded
                     {
                         StaticCollectionsClass.AddLeatherGenePawnToList(gene.pawn, extension.customLeatherThingDef);
                     }
+                    if (!extension.defsTreatedAsHumanMeat.NullOrEmpty())
+                    {
+                        StaticCollectionsClass.AddDefsTreatedAsHumanMeatGenePawnToList(gene.pawn, extension.defsTreatedAsHumanMeat);
+                    }
+                    if (!extension.defsTreatedAsHumanLeather.NullOrEmpty())
+                    {
+                        StaticCollectionsClass.AddDefsTreatedAsHumanLeatherGenePawnToList(gene.pawn, extension.defsTreatedAsHumanLeather);
+                    }
                     if (extension.customVomitThingDef != null)
                     {
                         StaticCollectionsClass.AddVomitTypeGenePawnToList(gene.pawn, extension.customVomitThingDef);
@@ -157,6 +165,14 @@ namespace VanillaGenesExpanded
                     if (extension.customBloodSmearThingDef != null)
                     {
                         StaticCollectionsClass.RemoveBloodSmearGenePawnFromList(gene.pawn);
+                    }
+                    if (!extension.defsTreatedAsHumanMeat.NullOrEmpty())
+                    {
+                        StaticCollectionsClass.RemoveDefsTreatedAsHumanMeatGenePawnFromList(gene.pawn);
+                    }
+                    if (!extension.defsTreatedAsHumanLeather.NullOrEmpty())
+                    {
+                        StaticCollectionsClass.RemoveDefsTreatedAsHumanLeatherGenePawnFromList(gene.pawn);
                     }
                     if (extension.customBloodIcon != "")
                     {

--- a/Source/VFECore/VFECore.csproj
+++ b/Source/VFECore/VFECore.csproj
@@ -465,6 +465,10 @@
     <Compile Include="AnimalBehaviours\Hediffs\Properties\HediffCompProperties_ExplodeOnFire.cs" />
     <Compile Include="AnimalBehaviours\Hediffs\Properties\HediffCompProperties_Ability.cs" />
     <Compile Include="AnimalBehaviours\Hediffs\Properties\HediffCompProperties_StageByHealth.cs" />
+    <Compile Include="Genes\Harmony\ThingIngestingPatches.cs" />
+    <Compile Include="Genes\Harmony\FoodUtility_GetMeatSourceCategory.cs" />
+    <Compile Include="Genes\Harmony\FoodUtility_GetMeatSourceCategoryFromCorpse.cs" />
+    <Compile Include="Genes\Harmony\ThoughtWorker_HumanLeatherApparel_CurrentThoughtState.cs" />
     <Compile Include="VFECore\Graphics\TaggedGraphics\Components.cs" />
     <Compile Include="VFECore\Graphics\TaggedGraphics\HarmonyPatches.cs" />
     <Compile Include="VFECore\Graphics\TaggedGraphics\PawnRenderNode_Omni.cs" />


### PR DESCRIPTION
`GeneExtension` now has 2 lists: `defsTreatedAsHumanMeat` and `defsTreatedAsHumanLeather`. Any defs they contain will cause pawns with those genes to treat those specified defs as human meat/leather, with all the negatives/positives.

I've opted to not using `customMeatThingDef` and `customLeatherThingDef` from `GeneExtension`, as some mods may want to make different defs treated as human meat/leather without those pawns actually having those. For example, this can be used for fungoid pawns as they treat eating fungus as cannibalism. The patches here will handle eating raw food, meals with ingredients, and corpses with the same meat type, and properly treat them as cannibalism. Likewise all clothing that made from stuff matching the provided defs will give the proper though for wearing human leather clothing.

This does not change vanilla handling of human meat/leather in any capacity, as that would require more complex patches and would be much less compatible with other mods.