### PR TITLE
Publicize AnimalBehaviours HediffComps, for easier patching

### DIFF
--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Ability.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Ability.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_Ability : HediffComp
+    public class HediffComp_Ability : HediffComp
     {
 
         public int tickCounter = 0;

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Animation.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Animation.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_Animation : HediffComp
+    public class HediffComp_Animation : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_DieAfterPeriod.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_DieAfterPeriod.cs
@@ -9,7 +9,7 @@ using VFECore;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_DieAfterPeriod : HediffComp
+    public class HediffComp_DieAfterPeriod : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Draftable.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Draftable.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_Draftable : HediffComp
+    public class HediffComp_Draftable : HediffComp
     {
 
         public int tickCounter = 0;

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Electrified.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Electrified.cs
@@ -4,7 +4,7 @@ using RimWorld;
 using System.Collections.Generic;
 namespace AnimalBehaviours
 {
-    class HediffComp_Electrified : HediffComp
+    public class HediffComp_Electrified : HediffComp
     {
         public HediffCompProperties_Electrified Props
         {

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Floating.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Floating.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_Floating : HediffComp
+    public class HediffComp_Floating : HediffComp
     {
 
         public int tickCounter = 0;

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_HeatPusher.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_HeatPusher.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_HeatPusher : HediffComp
+    public class HediffComp_HeatPusher : HediffComp
     {
 
        

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_HighlyFlammable.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_HighlyFlammable.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_HighlyFlammable : HediffComp
+    public class HediffComp_HighlyFlammable : HediffComp
     {
 
         public int tickCounter = 0;

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_LastStand.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_LastStand.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_LastStand : HediffComp
+    public class HediffComp_LastStand : HediffComp
     {
 
         public int tickCounter = 0;

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_LightSustenance.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_LightSustenance.cs
@@ -4,7 +4,7 @@ using RimWorld;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_LightSustenance : HediffComp
+    public class HediffComp_LightSustenance : HediffComp
     {
 
         public float growOptimalGlow = 0.4f;

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_NearbyEffecter.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_NearbyEffecter.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_NearbyEffecter : HediffComp
+    public class HediffComp_NearbyEffecter : HediffComp
     {
         public HediffCompProperties_NearbyEffecter Props
         {

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_PassiveRegenerator.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_PassiveRegenerator.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_PassiveRegenerator : HediffComp
+    public class HediffComp_PassiveRegenerator : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Regeneration.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Regeneration.cs
@@ -7,7 +7,7 @@ using Verse.AI;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_Regeneration : HediffComp
+    public class HediffComp_Regeneration : HediffComp
     {
         public HediffCompProperties_Regeneration Props
         {

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_RemoveFromMechs.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_RemoveFromMechs.cs
@@ -9,7 +9,7 @@ using AnimalBehaviours;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_RemoveFromMechs : HediffComp
+    public class HediffComp_RemoveFromMechs : HediffComp
     {
         public HediffCompProperties_RemoveFromMechs Props
         {

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Resurrect.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Resurrect.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_Resurrect : HediffComp
+    public class HediffComp_Resurrect : HediffComp
     {
         public HediffCompProperties_Resurrect Props
         {

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Spawner.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_Spawner.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_Spawner : HediffComp
+    public class HediffComp_Spawner : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageByHealth.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageByHealth.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_StageByHealth : HediffComp
+    public class HediffComp_StageByHealth : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageByPsylink.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageByPsylink.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_StageByPsylink : HediffComp
+    public class HediffComp_StageByPsylink : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageBySunlight.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageBySunlight.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_StageBySunlight : HediffComp
+    public class HediffComp_StageBySunlight : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageByTemperature.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_StageByTemperature.cs
@@ -9,7 +9,7 @@ using Verse.Noise;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_StageByTemperature : HediffComp
+    public class HediffComp_StageByTemperature : HediffComp
     {
 
 

--- a/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_ThoughtEffecter.cs
+++ b/Source/VFECore/AnimalBehaviours/Hediffs/HediffComp_ThoughtEffecter.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace AnimalBehaviours
 {
-    class HediffComp_ThoughtEffecter : HediffComp
+    public class HediffComp_ThoughtEffecter : HediffComp
     {
 
         public int tickCounter = 0;


### PR DESCRIPTION
Most of these are not set to public, meaning you can't access them directly, either for Harmony patches or other forms of mod integration/compatibility. Having to access these classes via reflection—when they by all means should be public—is silly.