### PR TITLE
Update PipeSystem.xml

### DIFF
--- a/Languages/English/Keyed/PipeSystem.xml
+++ b/Languages/English/Keyed/PipeSystem.xml
@@ -17,7 +17,7 @@
 
   <PipeSystem_ResourceStored>{0} stored:</PipeSystem_ResourceStored>
 
-  <PipeSystem_NotConnected>Not connected to {}.</PipeSystem_NotConnected>
+  <PipeSystem_NotConnected>Not connected to {0}.</PipeSystem_NotConnected>
   <PipeSystem_ExcessStored>{0} net excess/stored in network: {1} {3}/d / {2} {3}</PipeSystem_ExcessStored>
   <PipeSystem_Stored>{0} stored in network:</PipeSystem_Stored>
 


### PR DESCRIPTION
Missing argindex causes

`Could not resolve symbol "" for string "Not connected to {}.".`

when used