### PR TITLE
Configure project for C# 12.0 and RimWorld 1.6

### DIFF
--- a/Source/VEF/VEF.csproj
+++ b/Source/VEF/VEF.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>5</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -34,9 +34,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.9.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <SpecificVersion>False</SpecificVersion>
@@ -1333,6 +1338,9 @@
     <Compile Include="Weapons\Verbs\Verb_ShootWithSmoke.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Krafs.Rimworld.Ref">
+      <Version>1.6.4566</Version>
+    </PackageReference>
     <PackageReference Include="Lib.Harmony">
       <Version>2.4.1</Version>
       <ExcludeAssets>runtime</ExcludeAssets>


### PR DESCRIPTION
some IDEs error out if you just specify latest, this project uses C# 12.0... therefore explicitly state this. using rimworld ref allows this to work across systems, regardless of differences in folder structure.