### PR TITLE
CompApplyWeaponTraits NPE Fix

### DIFF
--- a/Source/VEF/Weapons/Comps/CompApplyWeaponTraits.cs
+++ b/Source/VEF/Weapons/Comps/CompApplyWeaponTraits.cs
@@ -291,8 +291,11 @@ namespace VEF.Weapons
             if (pawn.abilities != null && abilityWithCharges != null)
             {
                 Ability ability = pawn.abilities.GetAbility(abilityWithCharges);
-                maxCharges = ability.maxCharges;
-                currentCharges = ability.RemainingCharges;
+                if (ability != null)
+                {
+                    maxCharges = ability.maxCharges;
+                    currentCharges = ability.RemainingCharges;
+                }
                 pawn.abilities?.RemoveAbility(abilityWithCharges);
                 pawn.abilities?.Notify_TemporaryAbilitiesChanged();
             }


### PR DESCRIPTION
Sometimes `Pawn_AbilityTracker.GetAbility` can return `null`.

Fixes #179