### PR TITLE
Isolate optional feature activation failures

### DIFF
--- a/Source/VEF/OptionalFeatures/Defs/OptionalFeaturesDef.cs
+++ b/Source/VEF/OptionalFeatures/Defs/OptionalFeaturesDef.cs
@@ -13,6 +13,10 @@ namespace VEF.OptionalFeatures
         public string harmonyCategory;
         public bool IsActive { get; private set; } = false;
 
+        // Tracked separately from IsActive so a feature that threw is not retried by
+        // the next mod requesting it, while IsActive still reports what was patched.
+        private bool activationAttempted;
+
         public override void ResolveReferences()
         {
             base.ResolveReferences();
@@ -24,19 +28,34 @@ namespace VEF.OptionalFeatures
 
         public void Activate()
         {
-            if (IsActive)
+            if (activationAttempted)
                 return;
-            IsActive = true;
+            activationAttempted = true;
 
             if (activationClass != null && harmonyCategory != null)
                 Log.WarningOnce($"Feature {feature} has both {nameof(activationClass)} and {nameof(harmonyCategory)} specified, only {nameof(harmonyCategory)} will be used. Category: {harmonyCategory}, type: {activationClass}.", feature.GetHashCode());
 
-            if (!harmonyCategory.NullOrEmpty())
-                VEF_Mod.harmonyInstance.PatchCategory(harmonyCategory);
-            else if (activationMethod == null)
-                Log.ErrorOnce($"Feature {feature} with type {activationClass.ToStringSafe()} does not have ApplyFeature method or does not specify a harmony category", feature.GetHashCode());
-            else
-                activationMethod.Invoke(null, [VEF_Mod.harmonyInstance]);
+            try
+            {
+                if (!harmonyCategory.NullOrEmpty())
+                    VEF_Mod.harmonyInstance.PatchCategory(harmonyCategory);
+                else if (activationMethod == null)
+                {
+                    Log.ErrorOnce($"Feature {feature} with type {activationClass.ToStringSafe()} does not have ApplyFeature method or does not specify a harmony category", feature.GetHashCode());
+                    return;
+                }
+                else
+                    activationMethod.Invoke(null, [VEF_Mod.harmonyInstance]);
+
+                IsActive = true;
+            }
+            catch (Exception e)
+            {
+                // Unwrap the reflection wrapper so the log leads with the actual cause.
+                if (e is TargetInvocationException { InnerException: not null } tie)
+                    e = tie.InnerException;
+                Log.Error($"[VEF] Failed activating optional feature '{feature}'. Other optional features are unaffected, but this one may be partially applied. Exception:\n{e}");
+            }
         }
     }
 }

--- a/Source/VEF/OptionalFeatures/OptionalFeatures.cs
+++ b/Source/VEF/OptionalFeatures/OptionalFeatures.cs
@@ -20,7 +20,7 @@ namespace VEF.OptionalFeatures
                     }
                 }
 
-                foreach (var feature in DefDatabase<ModDef>.AllDefs.SelectMany(def => def.Activate))
+                foreach (var feature in DefDatabase<ModDef>.AllDefs.SelectMany(def => def.Activate ?? []))
                     if (feature != null && features.TryGetValue(feature, out var f))
                         f.Activate();
                     else Log.ErrorOnce($"Feature not found: {feature}", (feature ?? "null").GetHashCode());
@@ -30,6 +30,8 @@ namespace VEF.OptionalFeatures
 
     public class ModDef : Def
     {
-        public List<string> Activate;
+        // Consumer mods author these; a missing <Activate> node must not null-deref
+        // and take down activation for every feature.
+        public List<string> Activate = [];
     }
 }


### PR DESCRIPTION
## Problem

`OptionalFeatures` activates every requested feature in one unguarded `foreach` inside an `ExecuteWhenFinished` delegate. If any `ApplyFeature` throws, the exception escapes the delegate and every feature requested by a later-loading mod is silently never activated. Activation order is `DefDatabase<ModDef>` order, i.e. consumer mod load order, so which features survive depends on where the failing mod sits in the list.

Seen in a player log (1397 mods): the `IdeoFloatMenuPlus` transpiler on `IdeoUIUtility.AddPrecept` produced invalid IL under some other mod's patch of the same method. Alpha Memes requested it at load position 111; Vanilla Weapons Expanded requested `WeaponTraitDefMechanics` at 134, so none of the weapon trait mechanics applied (`VWE_BlastTips` stopped exploding, `VWE_SlipString` bows fired 1 shot instead of 3). The only log output was a single `Could not execute post-long-event action` line naming no feature, and the player reported it as a bug in an unrelated mod. Moving VWE above Alpha Memes restored the traits.

Two adjacent issues in the same loop:
- `ModDef.Activate` has no initializer, so a consumer `ModDef` without an `<Activate>` node null-derefs in the `SelectMany` and takes down activation for everything (MVCF's `ModDef.ActivateFeatures` already defaults to `new()`).
- `IsActive` is set before the patches run and never reverted, so a feature that threw is reported as active.

## Fix

- `OptionalFeaturesDef.Activate()`: wrap the `PatchCategory` / `ApplyFeature` call in try/catch, following `VEF_HarmonyCategories.RunPatches`. Run-once is tracked by a separate `activationAttempted` flag so a failed feature is not retried by the next mod requesting it; `IsActive` is only set after the patches succeed. `TargetInvocationException` is unwrapped so the error leads with the actual cause:

  ```
  [VEF] Failed activating optional feature 'IdeoFloatMenuPlus'. Other optional features are unaffected, but this one may be partially applied. Exception:
  System.InvalidProgramException: Invalid IL code in (wrapper dynamic-method) ...
  ```
- `ModDef.Activate` defaults to an empty list, plus a `?? []` at the call site.

Happy path is unchanged: same calls, same order, `IsActive` still ends up `true`.

## Verification

Red/green with Core + Ideology + Odyssey + VEF + Alpha Memes + VWE (Alpha Memes loaded first), injecting a fault into the `AddPrecept` transpiler (dropped the `Ldc_I4 30` so `bge` underflows, which Mono rejects at patch time exactly like the player's log):

- without the fix: `Could not execute post-long-event action ... TargetInvocationException ---> InvalidProgramException`, VWE trait mechanics dead.
- with the fix: the `[VEF] Failed activating optional feature 'IdeoFloatMenuPlus'` error above, loading continues, and unique-weapon traits (`VWE_BlastTips`, `VWE_SlipString`) work in-game.

Not addressed here: the `AddPrecept` transpiler itself is fragile (it splices after the first `WindowStack.Add` call it finds, assuming the option list is on top of the stack), which is presumably how it broke under the other mod. That is a separate fix.
