### PR TITLE
Avoid calling `GetStatValue` on null pawn

### DIFF
--- a/Source/VEF/Pawns/Harmony/Stat_Patches.cs
+++ b/Source/VEF/Pawns/Harmony/Stat_Patches.cs
@@ -42,7 +42,10 @@ namespace VEF.Pawns
     {
         public static void Postfix(Verb ownerVerb, Pawn attacker, ref float __result)
         {
-            __result *= attacker.GetStatValue(VEFDefOf.VEF_MeleeAttackDamageFactor);
+            if (attacker != null)
+            {
+                __result *= attacker.GetStatValue(VEFDefOf.VEF_MeleeAttackDamageFactor);
+            }
         }
     }
 


### PR DESCRIPTION
`VanillaExpandedFramework_AdjustedMeleeDamageAmount_Patch.Postfix` causes a null reference exception when developer tool “Output → General → Weapons Melee” is called. The reason is that it calls `VerbProperties.AdjustedMeleeDamageAmount` indirectly with a null pawn arguments, which triggers calling `GetStatValue` here. This PR adds a null check to fix the null reference exception.