### PR TITLE
Search for turret verb targets on an interval instead of every tick

### DIFF
--- a/Source/MVCF/VerbComps/VerbComp_Turret.cs
+++ b/Source/MVCF/VerbComps/VerbComp_Turret.cs
@@ -52,7 +52,7 @@ public class VerbComp_Turret : VerbComp_Draw
             return;
         }
 
-        if (!currentTarget.IsValid) currentTarget = TryFindNewTarget();
+        if (!currentTarget.IsValid && parent.Manager.Pawn.IsHashIntervalTick(Props.targetSearchIntervalTicks)) currentTarget = TryFindNewTarget();
 
         if (warmUpTicksLeft == 0) TryCast();
         else if (warmUpTicksLeft > 0) warmUpTicksLeft--;
@@ -140,5 +140,6 @@ public class VerbComp_Turret : VerbComp_Draw
 public class VerbCompProperties_Turret : VerbCompProperties_Draw
 {
     public bool invisible;
+    public int targetSearchIntervalTicks = 15;
     public bool uniqueTargets;
 }


### PR DESCRIPTION
`VerbComp_Turret.CompTick` calls `TryFindNewTarget()` on every tick that an idle
turret verb reaches that line, and each call is a full
`AttackTargetFinder.BestAttackTarget` search. Vanilla's `Building_TurretGun` runs
the same search once per 15 ticks (`TryStartShootSomethingIntervalTicks`). This
gates the call on the wearer's hash interval so the two match, with the interval
on `VerbCompProperties_Turret` and defaulting to 15.

The only behaviour change is that an idle turret can take up to 14 ticks longer
to notice a new enemy, which is what a vanilla turret already does. `CompTick`
handles `TryFindNewTarget` returning an invalid target on any tick, since that is
what happens when nothing is in range, so the gate does not introduce a state it
has not already seen.

Two notes on the shape. I gated the call site rather than putting the interval
inside `TryFindNewTarget`, so mods that subclass the comp and override the method
are covered too, and the protected method behaves as before for anything calling
it directly. And I put the interval on the properties rather than hardcoding 15,
since other mods use these comps and a faster turret might want a shorter one.
Happy to change either.