### PR TITLE
Fix cache clearing across world reloads

### DIFF
--- a/Source/VEF/Global/CacheClearing/ClearCaches.cs
+++ b/Source/VEF/Global/CacheClearing/ClearCaches.cs
@@ -37,7 +37,7 @@ public static class ClearCaches
             foreach (var field in type.GetFields(flags))
             {
                 if (field.HasAttribute<NoCacheClearingAttribute>())
-                    return;
+                    continue;
 
                 var fieldType = field.FieldType;
                 if (typeof(IDictionary).IsAssignableFrom(fieldType))

--- a/Source/VEF/Global/Harmony/MemoryUtility_UnloadUnusedUnityAssets.cs
+++ b/Source/VEF/Global/Harmony/MemoryUtility_UnloadUnusedUnityAssets.cs
@@ -10,3 +10,9 @@ public static class VanillaExpandedFramework_MemoryUtility_UnloadUnusedUnityAsse
 {
     private static void Postfix() => ClearCaches.ClearCache();
 }
+
+[HarmonyPatch(typeof(MemoryUtility), nameof(MemoryUtility.ClearAllMapsAndWorld))]
+public static class VanillaExpandedFramework_MemoryUtility_ClearAllMapsAndWorld
+{
+    private static void Postfix() => ClearCaches.ClearCache();
+}


### PR DESCRIPTION
VEF stops clearing a type's caches at the first [NoCacheClearing] field, leaving later caches untouched. It also misses the world-clear step used by Multiplayer reloads. Stale terrain effects can then stack and give astrorig wearers different movement speeds.

Skip only the protected field and run the existing cache cleaner when maps and world are cleared.

Tested: full build and focused regression checks passed. Single-player save/reload and astrorig movement passed across two reloads. Multiplayer hosting/reload, client join, and astrorig movement also passed, with matching movement costs and no desync during a short follow-up run.

